### PR TITLE
Tweak paths after recent renaming

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
       var respecConfig = {
           specStatus: "CG-DRAFT",
           shortName: "visualviewport",
-          edDraftURI: "https://wicg.github.io/visual-viewport/spec.html",
-          testSuiteURI: "https://github.com/w3c/web-platform-tests/tree/master/viewport",
+          edDraftURI: "https://wicg.github.io/visual-viewport/",
+          testSuiteURI: "https://github.com/w3c/web-platform-tests/tree/master/visual-viewport",
           editors: [
                 {   name:       "David Bokan",
                     url:        "",


### PR DESCRIPTION
The tests were renamed in https://github.com/w3c/web-platform-tests/pull/7984