### PR TITLE
Clarify relation to browsing context and window

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,13 +99,13 @@
           <dl>
             <dt><dfn data-dfn-for="Window">visualViewport</dfn></dt>
             <dd>
-              If the <a>window</a>'s associated <dfn data-cite="!HTML#document">Document</dfn> is
+              If the <a>window</a>'s <dfn data-cite="!HTML#concept-document-window">associated Document</dfn> is
               <dfn data-cite="!HTML#fully-active">fully active</dfn>, return the
               <a>VisualViewport</a> object associated with it. Otherwise, return null.
               <p class="note">
                 Intuitively, the VisualViewport object is only returned and useful for a <a>window</a> whose
-                <a>Document</a> is currently being presented. If a reference is retained to a
-                <a>VisualViewport</a> whose associated <a>Document</a> is not being currently presented, the
+                <dfn data-cite="!HTML#document">Document</dfn> is currently being presented. If a reference is retained to a
+                <a>VisualViewport</a> whose <a>associated Document</a> is not being currently presented, the
                 values in that <a>VisualViewport</a> must not reveal any information about the
                 <dfn data-cite="!HTML#browsing-context">browsing context</dfn>.
               <p>
@@ -118,7 +118,7 @@
             A <a>VisualViewport</a> object represents the visual viewport for a <a>window</a>'s
             <a>browsing context</a>. Each <a>window</a> on a page will have a unique
             <a>VisualViewport</a> object. This object represents the properties of the <a>window</a>'s
-            associated <a>Document</a>'s <a>browsing context</a> when that <a>Document</a> is
+            <a>associated Document</a>'s <a>browsing context</a> when that <a>Document</a> is
             </a>fully active</a>.
             <p class="example">
               For example: if a script retains a reference to a <a>VisualViewport</a> for an iframe, then
@@ -148,7 +148,7 @@
             <dt><dfn>offsetLeft</dfn></dt>
             <dd>
               <p>
-                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+                If the <a>window</a>'s <a>associated Document</a> is not <a>fully active</a>, return 0.
               </p>
               <p>
                 Otherwise, return the offset of the left edge of the visual viewport from the left edge
@@ -158,7 +158,7 @@
             <dt><dfn>offsetTop</dfn></dt>
             <dd>
               <p>
-                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+                If the <a>window</a>'s <a>associated Document</a> is not <a>fully active</a>, return 0.
               </p>
               <p>
                 Otherwise, return the offset of the top edge of the visual viewport from the top edge of
@@ -169,7 +169,7 @@
             <dt><dfn>pageLeft</dfn></dt>
             <dd>
               <p>
-                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+                If the <a>window</a>'s <a>associated Document</a> is not <a>fully active</a>, return 0.
               </p>
               <p>
                 Otherwise, return the x-coordinate, relative to the
@@ -180,7 +180,7 @@
             <dt><dfn>pageTop</dfn></dt>
             <dd>
               <p>
-                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+                If the <a>window</a>'s <a>associated Document</a> is not <a>fully active</a>, return 0.
               </p>
               <p>
                 Otherwise, return the y-coordinate, relative to the  <a>initial containing block</a>
@@ -191,7 +191,7 @@
             <dt><dfn>width</dfn></dt>
             <dd>
               <p>
-                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+                If the <a>window</a>'s <a>associated Document</a> is not <a>fully active</a>, return 0.
               </p>
               <p>
                 Otherwise, returs the width of the visual viewport in CSS pixels. This value
@@ -213,7 +213,7 @@
             <dt><dfn>height</dfn></dt>
             <dd>
               <p>
-                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+                If the <a>window</a>'s <a>associated Document</a> is not <a>fully active</a>, return 0.
               </p>
               <p>
                 Otherwise, return the height of the visual viewport in CSS pixels. This value
@@ -230,7 +230,7 @@
             <dd>
               Returns the pinch-zoom scaling factor applied to the visual viewport. It can be computed using the following algorithm:
               <ol>
-                <li data-md><p>If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0 and abort these steps.</p></li>
+                <li data-md><p>If the <a>window</a>'s <a>associated Document</a> is not <a>fully active</a>, return 0 and abort these steps.</p></li>
                 <li data-md><p>If there is no output device, return 1 and abort these steps.</p></li>
                 <li data-md>
                   <p>

--- a/index.html
+++ b/index.html
@@ -99,16 +99,15 @@
           <dl>
             <dt><dfn data-dfn-for="Window">visualViewport</dfn></dt>
             <dd>
-              If the <a>window</a> is currently in a <dfn data-cite="!HTML#windowproxy">WindowProxy</dfn>
-              object's <dfn data-cite="!HTML#concept-windowproxy-window">[[\Window]]</dfn> internal slot, return the
+              If the <a>window</a>'s associated <dfn data-cite="!HTML#document">Document</dfn> is
+              <dfn data-cite="!HTML#fully-active">fully active</dfn>, return the
               <a>VisualViewport</a> object associated with it. Otherwise, return null.
               <p class="note">
                 Intuitively, the VisualViewport object is only returned and useful for a <a>window</a> whose
-                <dfn data-cite="!HTML#document">Document</dfn> is currently being presented.
-                If a reference is retained to a <a>VisualViewport</a> that's not in a currently presented
-                <a>Document</a>, the values in that <a>VisualViewport</a> must not reveal any
-                information about the <dfn data-cite="!HTML#browsing-context">Browsing Context</dfn>.
-
+                <a>Document</a> is currently being presented. If a reference is retained to a
+                <a>VisualViewport</a> whose associated <a>Document</a> is not being currently presented, the
+                values in that <a>VisualViewport</a> must not reveal any information about the
+                <dfn data-cite="!HTML#browsing-context">browsing context</dfn>.
               <p>
             </dd>
           </dl>
@@ -116,16 +115,16 @@
         <section data-dfn-for="VisualViewport">
           <h3>The <dfn><code>VisualViewport</code></dfn> interface</h3>
           <p>
-            A <a>VisualViewport</a> object represents the visual viewport for a given <a>window</a>.
-            Each <a>window</a> on a page will have a unique <a>VisualViewport</a> object. This object
-            represents the properties of the <a>Browsing Context</a> whose <a>WindowProxy</a> object's
-            <a>[[\Window]]</a> internal slot contains the <a>window</a>. If the <a>window</a>
-            does not currently occupy a <a>[[\Window]]</a> internal slot, it must return 0 or null for
-            all its values.
+            A <a>VisualViewport</a> object represents the visual viewport for a <a>window</a>'s
+            <a>browsing context</a>. Each <a>window</a> on a page will have a unique
+            <a>VisualViewport</a> object. This object represents the properties of the <a>window</a>'s
+            associated <a>Document</a>'s <a>browsing context</a> when that <a>Document</a> is
+            </a>fully active</a>.
             <p class="example">
               For example: if a script retains a reference to a <a>VisualViewport</a> for an iframe, then
-              navigates the iframe to another location, reading values from the <a>VisualViewport</a>
-              reference should return 0.
+              navigates the iframe to another location, reading the integral values from the
+              <a>VisualViewport</a> reference will return 0 because its window's Document is no longer
+              being presented in a browsing content; it is no longer fully-active.
             <p>
           </p>
           <pre class="idl">
@@ -148,55 +147,90 @@
           <dl>
             <dt><dfn>offsetLeft</dfn></dt>
             <dd>
-              Returns the offset of the left edge of the visual viewport from the left edge of the layout viewport in CSS pixels.
+              <p>
+                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+              </p>
+              <p>
+                Otherwise, return the offset of the left edge of the visual viewport from the left edge
+                of the layout viewport in CSS pixels.
+              </p>
             </dd>
             <dt><dfn>offsetTop</dfn></dt>
             <dd>
-              Returns the offset of the top edge of the visual viewport from the top edge of the layout viewport in CSS pixels.
+              <p>
+                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+              </p>
+              <p>
+                Otherwise, return the offset of the top edge of the visual viewport from the top edge of
+                the layout viewport in CSS pixels.
+              </p>
             </dd>
 
             <dt><dfn>pageLeft</dfn></dt>
             <dd>
-              Returns the x-coordinate, relative to the <dfn data-cite="!CSS-DISPLAY-3#initial-containing-block">initial containing block</dfn> origin, of the left edge of the visual viewport in CSS pixels.
+              <p>
+                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+              </p>
+              <p>
+                Otherwise, return the x-coordinate, relative to the
+                <dfn data-cite="!CSS-DISPLAY-3#initial-containing-block">initial containing block</dfn>
+                origin, of the left edge of the visual viewport in CSS pixels.
+              </p>
             </dd>
             <dt><dfn>pageTop</dfn></dt>
             <dd>
-              Returns the y-coordinate, relative to the  <a>initial containing block</a> origin, of the top edge of the visual viewport in CSS pixels.
+              <p>
+                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+              </p>
+              <p>
+                Otherwise, return the y-coordinate, relative to the  <a>initial containing block</a>
+                origin, of the top edge of the visual viewport in CSS pixels.
+              </p>
             </dd>
 
             <dt><dfn>width</dfn></dt>
             <dd>
-              Returns the width of the visual viewport in CSS pixels. This value
-              excludes the width of any rendered
-              <dfn data-cite="!CSS-OVERFLOW-4#classic-scrollbars">classic scrollbar</dfn>
-              that is fixed to the visual viewport.
-              <div class="note">
-                A scrollbar that is fixed to the visual viewport is one that does
-                not change size or location as the visual viewport is zoomed and
-                panned.
+              <p>
+                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+              </p>
+              <p>
+                Otherwise, returs the width of the visual viewport in CSS pixels. This value
+                excludes the width of any rendered
+                <dfn data-cite="!CSS-OVERFLOW-4#classic-scrollbars">classic scrollbar</dfn>
+                that is fixed to the visual viewport.
+                <div class="note">
+                  A scrollbar that is fixed to the visual viewport is one that does
+                  not change size or location as the visual viewport is zoomed and
+                  panned.
 
-                Because this value is in CSS pixels, when excluding the scrollbar
-                width the UA must account for how large the scrollbar is in CSS
-                pixels. That is, the amount excluded is lessened if the viewport
-                is zoomed in and the scrollbars don't change size to the user.
-              </div>
+                  Because this value is in CSS pixels, when excluding the scrollbar
+                  width the UA must account for how large the scrollbar is in CSS
+                  pixels. That is, the amount excluded is lessened if the viewport
+                  is zoomed in and the scrollbars don't change size to the user.
+                </div>
+              </p>
             </dd>
             <dt><dfn>height</dfn></dt>
             <dd>
-              Returns the height of the visual viewport in CSS pixels. This value
-              excludes the height of any rendered
-              <a>classic scrollbar</a>
-              that is fixed to the visual viewport.
-              <div class="note">
-                Because both the width and height attributes are expressed in CSS pixels, increasing either
-                page-zoom or pinch-zoom will cause these values to shrink.
-              </div>
+              <p>
+                If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0.
+              </p>
+              <p>
+                Otherwise, return the height of the visual viewport in CSS pixels. This value
+                excludes the height of any rendered
+                <a>classic scrollbar</a>
+                that is fixed to the visual viewport.
+                <div class="note">
+                  Because both the width and height attributes are expressed in CSS pixels, increasing either
+                  page-zoom or pinch-zoom will cause these values to shrink.
+                </div>
+              </p>
             </dd>
             <dt><dfn>scale</dfn></dt>
             <dd>
               Returns the pinch-zoom scaling factor applied to the visual viewport. It can be computed using the following algorithm:
-
               <ol>
+                <li data-md><p>If the <a>window</a>'s associated <a>Document</a> is not <a>fully active</a>, return 0 and abort these steps.</p></li>
                 <li data-md><p>If there is no output device, return 1 and abort these steps.</p></li>
                 <li data-md>
                   <p>

--- a/index.html
+++ b/index.html
@@ -99,17 +99,34 @@
           <dl>
             <dt><dfn data-dfn-for="Window">visualViewport</dfn></dt>
             <dd>
-              If the <code>window</code> has a <dfn data-cite="!HTML#browsing-context">Browsing Context</dfn> set,
-              return the <a>VisualViewport</a> object associated with it. Otherwise, return null.
+              If the <a>window</a> is currently in a <dfn data-cite="!HTML#windowproxy">WindowProxy</dfn>
+              object's <dfn data-cite="!HTML#concept-windowproxy-window">[[\Window]]</dfn> internal slot, return the
+              <a>VisualViewport</a> object associated with it. Otherwise, return null.
+              <p class="note">
+                Intuitively, the VisualViewport object is only returned and useful for a <a>window</a> whose
+                <dfn data-cite="!HTML#document">Document</dfn> is currently being presented.
+                If a reference is retained to a <a>VisualViewport</a> that's not in a currently presented
+                <a>Document</a>, the values in that <a>VisualViewport</a> must not reveal any
+                information about the <dfn data-cite="!HTML#browsing-context">Browsing Context</dfn>.
+
+              <p>
             </dd>
           </dl>
         </section>
         <section data-dfn-for="VisualViewport">
           <h3>The <dfn><code>VisualViewport</code></dfn> interface</h3>
           <p>
-            A <a>VisualViewport</a> object represents the visual viewport for a given <code>browsing context</code>.
-            Each <code>window</code> on a page will have a unique <a>VisualViewport</a> object representing
-            the properties associated with the <code>window</code>'s <code>browsing context</code>.
+            A <a>VisualViewport</a> object represents the visual viewport for a given <a>window</a>.
+            Each <a>window</a> on a page will have a unique <a>VisualViewport</a> object. This object
+            represents the properties of the <a>Browsing Context</a> whose <a>WindowProxy</a> object's
+            <a>[[\Window]]</a> internal slot contains the <a>window</a>. If the <a>window</a>
+            does not currently occupy a <a>[[\Window]]</a> internal slot, it must return 0 or null for
+            all its values.
+            <p class="example">
+              For example: if a script retains a reference to a <a>VisualViewport</a> for an iframe, then
+              navigates the iframe to another location, reading values from the <a>VisualViewport</a>
+              reference should return 0.
+            <p>
           </p>
           <pre class="idl">
             interface VisualViewport : EventTarget {


### PR DESCRIPTION
Make it clear in the spec that the VisualViewport is associated with the Window
object. However, it is affected by whether the Window's Document is currently
being presented in a Browsing Context.

Fixes #56 