### PR TITLE
Prevent the dummy iframe from intercepting events

### DIFF
--- a/polyfill/visualViewport.js
+++ b/polyfill/visualViewport.js
@@ -10,6 +10,7 @@ function updateUnscaledDimensions() {
       iframe.style.top="0px";
       iframe.style.border="0";
       iframe.style.visibility="hidden";
+      iframe.style.zIndex="-1";
       iframe.srcdoc = "<!DOCTYPE html><html><body style='margin:0px; padding:0px'></body></html>";
 
       document.body.appendChild(iframe);


### PR DESCRIPTION
On Mobile Safari the invisible iframe is on top of all elements,
which causes some links not to work. This fix places the iframe below them.

Honestly, I cannot explain why an iframe with `visibility: hidden` should receive any touch or click event at all. Using the DOM inspector on the iPhone I noticed that that's exactly what's happening – removing the iframe or lowering it's z-index made all links on the page work again.

**EDIT:** Are there any plans on publishing this on npm? This polyfill is very useful and I'm glad I found it.